### PR TITLE
Bugfix if empty TEs list is given it will also calculate TEs

### DIFF
--- a/multiecho/combination.py
+++ b/multiecho/combination.py
@@ -34,7 +34,7 @@ def load_me_data(pattern: Path, TEs: Optional[Tuple[float]]) -> Tuple[List[Tuple
 
     datafiles = sorted(pattern.parent.glob(pattern.name))
 
-    if TEs is None:
+    if not TEs:
         jsonfiles = [datafile.with_suffix('').with_suffix('.json') for datafile in datafiles]
         TEs       = [json.load(jsonfile.open('r'))['EchoTime']     for jsonfile in jsonfiles]
 


### PR DESCRIPTION
Hi Marcel, 

I think this is where it went wrong, I remember updating this in my personal multiecho copy. I think it is necessary since we give an empty list of TEs with the command and don't necessarily set it to None. 

Thanks, 
Jorryt