### PR TITLE
Do not install tests in site-packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requirements = (Path(__file__).parent/'requirements.txt').read_text().splitlines
 
 setup(name                          = 'multiecho',          # Required
       version                       = version,              # Required
-      packages                      = find_packages(),      # Required
+      packages                      = find_packages(exclude=['tests*']),      # Required
       install_requires              = requirements,
       tests_require                 = ['coverage', 'pytest'],
       entry_points                  = {'console_scripts': ['mecombine = multiecho.combination:main']},


### PR DESCRIPTION
Fixes:

```
python3.11 -m venv _e
. _e/bin/activate
pip install multiecho
ls -l _e/lib/python3.11/site-packages/tests/
```

```
total 4
-rw-r--r--. 1 ben ben   0 Jul  1 20:53 __init__.py
drwxr-xr-x. 1 ben ben 114 Jul  1 20:53 __pycache__
-rw-r--r--. 1 ben ben 494 Jul  1 20:53 test_load_me_data.py
```

That is, `multiecho` is incorrectly installing its `tests/` as a top-level `tests` package.