### PR TITLE
Use argparse-manpage (fix #18)

### DIFF
--- a/multiecho/_args.py
+++ b/multiecho/_args.py
@@ -1,0 +1,39 @@
+"""Argument parsing for the mecombine tool"""
+
+import argparse
+import textwrap
+
+doc = """Combine multi-echo echoes.
+
+Tools to combine multiple echoes from an fMRI acquisition.
+It expects input files saved as NIfTIs, preferably organised
+according to the BIDS standard.
+
+Currently three different combination algorithms are supported, implementing
+the following weighting schemes:
+
+1. PAID => TE * SNR
+2. TE => TE
+3. Simple Average => 1
+"""
+
+class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
+        pass
+
+def make_parser():
+    parser = argparse.ArgumentParser(prog='mecombine',
+                                     formatter_class=CustomFormatter,
+                                     description=textwrap.dedent(doc),
+                                     epilog="examples:\n"
+                                            "  mecombine '/project/number/bids/sub-001/func/*_task-motor_*echo-*.nii.gz'\n"
+                                            "  mecombine '/project/number/bids/sub-001/func/*_task-rest_*echo-*.nii.gz' -a PAID\n"
+                                            "  mecombine '/project/number/bids/sub-001/func/*_acq-MBME_*run-01*.nii.gz' -w 11 22 33 -o sub-001_task-stroop_acq-mecombined_run-01_bold.nii.gz\n ")
+
+    parser.add_argument('pattern', type=str, help='Globlike search pattern with path to select the echo images that need to be combined. Because of the search, be sure to check that not too many files are being read')
+    parser.add_argument('-o','--outputname', type=str, default='', help="File output name. If not a fullpath name, then the output will be stored in the same folder as the input. If empty, the output filename will be the filename of the first echo appended with a '_combined' suffix")
+    parser.add_argument('-a','--algorithm', default='TE', choices=['PAID', 'TE', 'average'], help='Combination algorithm. Default: TE')
+    parser.add_argument('-w','--weights', nargs='*', default=None, type=float, help='Weights (e.g. = echo times) for all echoes')
+    parser.add_argument('-s','--saveweights', action='store_true', help='If passed and algorithm is PAID, save weights')
+    parser.add_argument('-v','--volumes', type=int, default=100, help='Number of volumes that is used to compute the weights if algorithm is PAID')
+
+    return parser

--- a/multiecho/combination.py
+++ b/multiecho/combination.py
@@ -1,18 +1,4 @@
 #!/usr/bin/env python3
-"""Combine multi-echo echoes.
-
-Tools to combine multiple echoes from an fMRI acquisition.
-It expects input files saved as NIfTIs, preferably organised
-according to the BIDS standard.
-
-Currently three different combination algorithms are supported, implementing
-the following weighting schemes:
-
-1. PAID => TE * SNR
-2. TE => TE
-3. Simple Average => 1
-"""
-
 import argparse
 import textwrap
 import json
@@ -24,6 +10,8 @@ from typing import List, Optional, Tuple
 
 import nibabel as nib
 import numpy as np
+
+from . import _args
 
 LOGGER = logging.getLogger(__name__)
 
@@ -184,20 +172,7 @@ def main():
     class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
         pass
 
-    parser = argparse.ArgumentParser(formatter_class=CustomFormatter,
-                                     description=textwrap.dedent(__doc__),
-                                     epilog="examples:\n"
-                                            "  mecombine '/project/number/bids/sub-001/func/*_task-motor_*echo-*.nii.gz'\n"
-                                            "  mecombine '/project/number/bids/sub-001/func/*_task-rest_*echo-*.nii.gz' -a PAID\n"
-                                            "  mecombine '/project/number/bids/sub-001/func/*_acq-MBME_*run-01*.nii.gz' -w 11 22 33 -o sub-001_task-stroop_acq-mecombined_run-01_bold.nii.gz\n ")
-    parser.add_argument('pattern', type=str, help='Globlike search pattern with path to select the echo images that need to be combined. Because of the search, be sure to check that not too many files are being read')
-    parser.add_argument('-o','--outputname', type=str, default='', help="File output name. If not a fullpath name, then the output will be stored in the same folder as the input. If empty, the output filename will be the filename of the first echo appended with a '_combined' suffix")
-    parser.add_argument('-a','--algorithm', default='TE', choices=['PAID', 'TE', 'average'], help='Combination algorithm. Default: TE')
-    parser.add_argument('-w','--weights', nargs='*', default=None, type=float, help='Weights (e.g. = echo times) for all echoes')
-    parser.add_argument('-s','--saveweights', action='store_true', help='If passed and algorithm is PAID, save weights')
-    parser.add_argument('-v','--volumes', type=int, default=100, help='Number of volumes that is used to compute the weights if algorithm is PAID')
-
-    args = parser.parse_args()
+    args = _args.make_parser().parse_args()
 
     me_combine(pattern=args.pattern, outputname=args.outputname, algorithm=args.algorithm, weights=args.weights, saveweights=args.saveweights, volumes=args.volumes)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ url          = 'https://github.com/Donders-Institute/multiecho'
 python_version = ['3.6', '3.7', '3.8', '3.9', 3.10]
 
 [build-system]
-requires = ['setuptools', 'wheel']
+requires = ['setuptools', 'wheel', 'argparse-manpage[setuptools]']
 
 [tool.hatch.commands]
 prerelease = 'hatch build'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[build_manpages]
+manpages =
+    man/mecombine.1:function=make_parser:pyfile=multiecho/_args.py

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from setuptools import setup, find_packages
+from build_manpages import build_manpages, get_build_py_cmd, get_install_cmd
 
 # Read the version from file
 version = (Path(__file__).parent/'version.txt').read_text().strip()
@@ -16,6 +17,9 @@ setup(name                          = 'multiecho',          # Required
       install_requires              = requirements,
       tests_require                 = ['coverage', 'pytest'],
       entry_points                  = {'console_scripts': ['mecombine = multiecho.combination:main']},
+      cmdclass                      = {'build_manpages': build_manpages,
+                                       'build_py': get_build_py_cmd(),
+                                       'install': get_install_cmd()},
       description                   = 'Combine multi-echoes from a multi-echo fMRI acquisition.',
       long_description              = readme,
       long_description_content_type = 'text/markdown',

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
 [testenv]
 passenv = *
 deps =
+    argparse-manpage[setuptools]
     coverage
     pytest
 commands =


### PR DESCRIPTION
I took a shot at using https://pypi.org/project/argparse-manpage/. This seems to work correctly. The result appears not *quite* as nice as hand-written, but more than good enough.

The purpose of moving argument parser creation into a different module is to minimize dependencies; anything that needs to be imported to create the man page would have to become part of the `build-system` `requires`, so it’s nice to limit that to the standard library.

Quibbles welcome.